### PR TITLE
Add site-packages population script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           ./scripts/build-openssl.sh
           ./scripts/build-gdbm.sh
           ./scripts/build-python.sh
+          ./scripts/populate-site-packages.sh
 
       - name: Package output
         run: |

--- a/scripts/populate-site-packages.sh
+++ b/scripts/populate-site-packages.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PREFIX="$HOME/sysroot"
+SITE_PACKAGES_DIR="$PREFIX/lib/python3.2/site-packages"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARCHIVES_DIR="$REPO_ROOT/site-packages"
+
+mkdir -p "$SITE_PACKAGES_DIR"
+
+for archive in "$ARCHIVES_DIR"/*.as-installed.tar.gz; do
+  [ -e "$archive" ] || continue
+  tar -xf "$archive" -C "$SITE_PACKAGES_DIR"
+done
+


### PR DESCRIPTION
## Summary
- add populate-site-packages script to unpack site-packages tarballs
- call populate-site-packages during GitHub Actions build

## Testing
- `bash -n scripts/populate-site-packages.sh`
- `HOME=/tmp/test_home bash scripts/populate-site-packages.sh`

------
https://chatgpt.com/codex/tasks/task_b_684647d8eed48326a3d656f16d785179