### PR TITLE
Add build step for portable executable wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ chmod +x scripts/*.sh
 ./scripts/build-openssl.sh
 ./scripts/build-gdbm.sh
 ./scripts/build-python.sh
+./scripts/apply-portable-executable-wrapper.sh
 ```
 
 ## Use the Environment

--- a/scripts/apply-portable-executable-wrapper.sh
+++ b/scripts/apply-portable-executable-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PREFIX="$HOME/sysroot"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$REPO_ROOT/src/wrapper"
+make
+scripts/apply-wrapper -w wrapper "$PREFIX/bin"


### PR DESCRIPTION
## Summary
- add a script to compile the wrapper and apply it to installed binaries
- document the new step in the build instructions

## Testing
- `bash -n scripts/apply-portable-executable-wrapper.sh`
- `./scripts/apply-portable-executable-wrapper.sh`

------
https://chatgpt.com/codex/tasks/task_b_68464be2853c8326b1ca21097dd97ec0