### PR TITLE
Add OS-specific build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
@@ -27,9 +30,9 @@ jobs:
       - name: Package output
         run: |
           cd $HOME/sysroot
-          sudo tar -cJf ${{ github.workspace }}/python-3.2.5.tar.xz .
+          sudo tar -cJf ${{ github.workspace }}/python-3.2.5-${{ matrix.os }}.tar.xz .
 
       - name: Upload binary
         uses: softprops/action-gh-release@v1
         with:
-          files: python-3.2.5.tar.xz
+          files: python-3.2.5-${{ matrix.os }}.tar.xz

--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ Reproducible rebuild of Python 3.2.5 for Ubuntu 20.04 systems with statically li
 
 ## Binary Installation
 ```bash
-wget https://github.com/phdye/python-3.2.5-repack/releases/download/v3.2.5/python-3.2.5.tar.xz
-sudo tar -C /opt -xf python-3.2.5.tar.xz
+# Example for Ubuntu 20.04
+wget https://github.com/phdye/python-3.2.5-repack/releases/download/v3.2.5/python-3.2.5-ubuntu-20.04.tar.xz
+sudo tar -C /opt -xf python-3.2.5-ubuntu-20.04.tar.xz
 export PATH="/opt/python-3.2.5/bin:$PATH"
 ```
+You can also use the provided `install.sh` script:
+```bash
+./install.sh python-3.2.5-ubuntu-20.04.tar.xz
+```
+
+Artifacts are named `python-3.2.5-<os>.tar.xz`, where `<os>` matches
+the target platform (e.g., `ubuntu-22.04`).
 
 ## Use the Environment
 

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 PREFIX="/opt/python-3.2.5"
+TARBALL="${1:-python-3.2.5-ubuntu-20.04.tar.xz}"
 
-echo "Installing Python 3.2.5 to ${PREFIX}..."
+echo "Installing Python 3.2.5 to ${PREFIX} using $TARBALL..."
 sudo mkdir -p "$PREFIX"
-sudo tar -xf python-3.2.5.tar.xz -C /opt
+sudo tar -xf "$TARBALL" -C /opt
 
 echo ""
 echo "✅ Python 3.2.5 installed at $PREFIX"


### PR DESCRIPTION
## Summary
- support multiple build environments with a matrix
- use `${{ matrix.os }}` in artifact name
- update README binary install example for ubuntu-20.04
- allow `install.sh` to specify the tarball

## Testing
- `bash -n install.sh`
- `bash -n .github/workflows/build.yml`

------
https://chatgpt.com/codex/tasks/task_b_6846535511ec8326b57626e46d35b2ef