### PR TITLE
Add relative RPATHs to build scripts

### DIFF
--- a/scripts/build-gdbm.sh
+++ b/scripts/build-gdbm.sh
@@ -20,7 +20,9 @@ fi
 tar -xf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
-CFLAGS="-fPIC -O2" ./configure --prefix="$PREFIX" --enable-libgdbm-compat
+CFLAGS="-fPIC -O2" \
+LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib" \
+    ./configure --prefix="$PREFIX" --enable-libgdbm-compat
 make -j"$(nproc)"
 make install
 

--- a/scripts/build-openssl.sh
+++ b/scripts/build-openssl.sh
@@ -20,6 +20,8 @@ fi
 tar -xzf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
-CFLAGS="-fPIC -O2" ./Configure linux-x86_64 --prefix="$PREFIX" --openssldir="$PREFIX/ssl" no-ssl2 no-ssl3 shared
+CFLAGS="-fPIC -O2" \
+LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib" \
+    ./Configure linux-x86_64 --prefix="$PREFIX" --openssldir="$PREFIX/ssl" no-ssl2 no-ssl3 shared
 make -j"$(nproc)"
 make install_sw

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -25,7 +25,7 @@ tar -xzf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
 export CFLAGS="-fPIC -O2 -I${PREFIX}/include -DHAVE_MEMMOVE"
-export LDFLAGS="-L${PREFIX}/lib"
+export LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib"
 export PATH="$PREFIX/bin:$PATH"
 export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
 

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -26,8 +26,8 @@ export MAKEFLAGS="-j$(nproc)"
 export PATH="$PREFIX/bin:$PATH"
 export CFLAGS="${CFLAGS} -O2 -fPIC"
 export CPPFLAGS="${CFLAGS} ${CPPFLAGS}"
-export LDFLAGS="${LDFLAGS}"
-# -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib"
+# Embed a relative RPATH so binaries remain relocatable
+export LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib ${LDFLAGS}"
 
 export MAKE="make"
 


### PR DESCRIPTION
## Summary
- embed `$ORIGIN/../lib` in LDFLAGS so binaries are relocatable
- apply RPATH to OpenSSL, GDBM and Python builds

## Testing
- `bash -n scripts/builder.sh`
- `bash -n scripts/build-openssl.sh`
- `bash -n scripts/build-gdbm.sh`
- `bash -n scripts/build-python.sh`

------
https://chatgpt.com/codex/tasks/task_b_68737e9a07d8832685877c3888f36853