### PR TITLE
Fix $ORIGIN rpath quoting

### DIFF
--- a/scripts/build-gdbm.sh
+++ b/scripts/build-gdbm.sh
@@ -21,7 +21,7 @@ tar -xf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
 CFLAGS="-fPIC -O2" \
-LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib" \
+LDFLAGS="-Wl,-rpath,\\\$\$ORIGIN/../lib -L${PREFIX}/lib" \
     ./configure --prefix="$PREFIX" --enable-libgdbm-compat
 make -j"$(nproc)"
 make install

--- a/scripts/build-openssl.sh
+++ b/scripts/build-openssl.sh
@@ -21,7 +21,7 @@ tar -xzf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
 CFLAGS="-fPIC -O2" \
-LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib" \
+LDFLAGS="-Wl,-rpath,\\\$\$ORIGIN/../lib -L${PREFIX}/lib" \
     ./Configure linux-x86_64 --prefix="$PREFIX" --openssldir="$PREFIX/ssl" no-ssl2 no-ssl3 shared
 make -j"$(nproc)"
 make install_sw

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -25,7 +25,7 @@ tar -xzf "$TARBALL" -C "$SRC"
 cd "$SRC_DIR"
 
 export CFLAGS="-fPIC -O2 -I${PREFIX}/include -DHAVE_MEMMOVE"
-export LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib"
+export LDFLAGS="-Wl,-rpath,\\\$\$ORIGIN/../lib -L${PREFIX}/lib"
 export PATH="$PREFIX/bin:$PATH"
 export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
 

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -27,7 +27,10 @@ export PATH="$PREFIX/bin:$PATH"
 export CFLAGS="${CFLAGS} -O2 -fPIC"
 export CPPFLAGS="${CFLAGS} ${CPPFLAGS}"
 # Embed a relative RPATH so binaries remain relocatable
-export LDFLAGS="-Wl,-rpath,\$ORIGIN/../lib -L${PREFIX}/lib ${LDFLAGS}"
+# Embed a literal "$ORIGIN" token so the resulting binaries have a
+# relocatable RPATH. A single backslash is consumed by the shell and the
+# double dollar is reduced to a single dollar by make.
+export LDFLAGS="-Wl,-rpath,\\\$\$ORIGIN/../lib -L${PREFIX}/lib ${LDFLAGS}"
 
 export MAKE="make"
 


### PR DESCRIPTION
## Summary
- quote `$ORIGIN` correctly when exporting `LDFLAGS`
- update build scripts to embed relocatable RPATHs properly

## Testing
- `python3 scripts/diagnose-env.py >/tmp/env.txt`

------
https://chatgpt.com/codex/tasks/task_b_687394d4b4488326b0e6aed04a7b891c