### PR TITLE
Ensure relocatable builds

### DIFF
--- a/scripts/build-sysroot.sh
+++ b/scripts/build-sysroot.sh
@@ -23,3 +23,11 @@ export LD_LIBRARY_PATH=
 ./scripts/build-python.sh
 
 ./scripts/populate-site-packages.sh
+
+# Ensure the resulting toolchain is fully relocatable by rewriting
+# RPATH entries to use paths relative to each binary's location.
+find "$PREFIX" -type f -print0 | while IFS= read -r -d '' file; do
+  if file "$file" | grep -q ELF; then
+    patchelf --set-rpath '$ORIGIN/../lib' "$file" 2>/dev/null || true
+  fi
+done

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -10,7 +10,7 @@ sudo apt update
 
 sudo apt upgrade -y
 
-sudo apt install -y build-essential libc6-dev
+sudo apt install -y build-essential libc6-dev patchelf
 
 #----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add patchelf to build dependencies
- rewrite RPATH of built binaries to make sysroot relocatable

## Testing
- `bash -n scripts/install-deps.sh`
- `bash -n scripts/build-sysroot.sh`


------
https://chatgpt.com/codex/tasks/task_b_6894956966a8832691018eee824e503d